### PR TITLE
returning without processing result of the query in case out pipeline

### DIFF
--- a/src/main/java/com/cisco/spring/data/mongodb/test/beans/query/AggregateQueryProvider.java
+++ b/src/main/java/com/cisco/spring/data/mongodb/test/beans/query/AggregateQueryProvider.java
@@ -121,6 +121,11 @@ public class AggregateQueryProvider implements QueryProvider, Iterator<String> {
   }
 
   @Override
+  public Class getMethodReturnType() {
+    return method.getReturnType();
+  }
+
+  @Override
   public boolean hasNext() {
     return queryIterator.hasNext();
   }

--- a/src/main/java/com/cisco/spring/data/mongodb/test/beans/query/JongoQueryExecutor.java
+++ b/src/main/java/com/cisco/spring/data/mongodb/test/beans/query/JongoQueryExecutor.java
@@ -90,7 +90,7 @@ public class JongoQueryExecutor implements MongoQueryExecutor {
     //ResultsIterator resultsIterator = aggregate.options(aggregationOptions).as(resultMap.getClass());
 
     ResultsIterator resultsIterator = aggregate.as(resultMap.getClass());
-    if (!resultsIterator.hasNext()) {
+    if (!resultsIterator.hasNext() || Void.TYPE.equals(queryProvider.getMethodReturnType())) {
       return null;
     }
     final String resultKey = queryProvider.getQueryResultKey();

--- a/src/main/java/com/cisco/spring/data/mongodb/test/beans/query/QueryProvider.java
+++ b/src/main/java/com/cisco/spring/data/mongodb/test/beans/query/QueryProvider.java
@@ -50,6 +50,11 @@ public interface QueryProvider {
   boolean returnCollection();
 
   /**
+   * @return repository's aggregate function's return type
+   */
+  Class getMethodReturnType();
+
+  /**
    * @return result key
    */
   String getQueryResultKey();

--- a/src/test/java/com/cisco/spring/data/mongodb/tests/AggregateOutTest.java
+++ b/src/test/java/com/cisco/spring/data/mongodb/tests/AggregateOutTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
@@ -50,8 +51,11 @@ public class AggregateOutTest extends AbstractTestNGSpringContextTests {
   @Test
   public void outMustPlaceRepositoryObjectsInDifferentRepository() {
     TestAggregateAnnotation2FieldsBean obj1 = new TestAggregateAnnotation2FieldsBean(randomAlphabetic(10));
+    obj1.setOid(UUID.randomUUID().toString());
     TestAggregateAnnotation2FieldsBean obj2 = new TestAggregateAnnotation2FieldsBean(randomAlphabetic(20),
                                                                                      nextInt(1, 10000));
+    obj2.setOid(UUID.randomUUID().toString());
+
     testAggregateRepository2.save(obj1);
     testAggregateRepository2.save(obj2);
     String outputRepoName = "temp1";


### PR DESCRIPTION
If aggregate pipeline has $out, there will not be any return for repository's aggregate function. returning without processing result of the query
