### PR TITLE
Always generate randomLongs that _require_ eight bytes to represent

### DIFF
--- a/src/test/java/com/cisco/mongodb/aggregate/support/test/repository/TestLongRepository.java
+++ b/src/test/java/com/cisco/mongodb/aggregate/support/test/repository/TestLongRepository.java
@@ -32,22 +32,22 @@ import java.util.List;
 public interface TestLongRepository extends MongoRepository<TestLongBean, String> {
 
   @Aggregate2(name = "getRandomLong", inputType = TestLongBean.class, outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomLong' : #}", order = 0)
+  @Match2(query = "{'randomLong' : ?0 }", order = 0)
   TestLongBean getRandomLong(Long longValue);
 
   @Aggregate2(name = "queryWithAnArrayOfLongs", inputType = TestLongBean.class,
           outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomLong' : { $in : # }}", order = 0)
+  @Match2(query = "{'randomLong' : { $in : ?0 }}", order = 0)
   List<TestLongBean> queryWithAnArrayOfLongs(long[] randomLongArray);
 
   @Aggregate2(name = "queryWithAListOfLongs", inputType = TestLongBean.class,
           outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomLong' : { $in : # }}", order = 0)
+  @Match2(query = "{'randomLong' : { $in : ?0 }}", order = 0)
   List<TestLongBean> queryWithAListOfLongs(List<Long> randomLongList);
 
   @Aggregate2(name = "queryWithALongAndFacet", inputType = TestLongBean.class,
           outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomLong' : { $in : # }}", order = 0)
+  @Match2(query = "{'randomLong' : { $in : ?0 }}", order = 0)
   @FacetPipeline(name = "testFacet", stages = {
           @FacetPipelineStage(stageType = Limit2.class,
                   query = "?1")
@@ -56,22 +56,22 @@ public interface TestLongRepository extends MongoRepository<TestLongBean, String
 
   @Aggregate2(name = "queryWithMixOfSpringAndJongoPlaceholders", inputType = TestLongBean.class,
               outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomString' : ?0, 'randomLong' : #}", order = 0)
+  @Match2(query = "{'randomString' : ?0, 'randomLong' : ?1 }", order = 0)
   TestLongBean queryWithMixOfSpringAndJongoPlaceholders(String randomString, long randomLong);
 
   @Aggregate2(name = "queryWithMixOfSpringAndJongoPlaceholdersRegardlessOfOrder", inputType = TestLongBean.class,
               outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomString' : ?1, 'randomLong' : #}", order = 0)
+  @Match2(query = "{'randomString' : ?1, 'randomLong' : ?0 }", order = 0)
   TestLongBean queryWithMixOfSpringAndJongoPlaceholdersRegardlessOfOrder(long randomLong, String randomString);
 
   @Aggregate2(name = "queryWithMultipleTemplateEnginePlaceholders", inputType = TestLongBean.class,
               outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomLong' : #, 'randomLong2' : #}", order = 0)
+  @Match2(query = "{'randomLong' : ?0, 'randomLong2' : ?1}", order = 0)
   TestLongBean queryWithMultipleTemplateEnginePlaceholders(long randomLong, long randomLong2);
 
   @Aggregate2(name = "queryWithMultipleTemplateEnginePlaceholdersAndSpringPlaceholders", inputType = TestLongBean.class,
               outputBeanType = TestLongBean.class)
-  @Match2(query = "{'randomString':?1, 'randomLong' : #, 'randomLong2' : #}", order = 0)
+  @Match2(query = "{'randomString':?1, 'randomLong' : ?0, 'randomLong2' : ?2}", order = 0)
   TestLongBean queryWithMultipleTemplateEnginePlaceholdersAndSpringPlaceholders(long randomLong, String springPlaceholder,
                                                                                 long randomLong2);
 }

--- a/src/test/java/com/cisco/mongodb/aggregate/support/test/tests/NumberLongTest.java
+++ b/src/test/java/com/cisco/mongodb/aggregate/support/test/tests/NumberLongTest.java
@@ -45,10 +45,17 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Autowired
   private TestLongRepository testLongRepository;
 
+  private static long generateRandomEightByteLong() {
+    long result = (System.currentTimeMillis() / 1000) << 32;
+    result += RandomUtils.nextInt(0, Integer.MAX_VALUE);
+    System.err.println("generateRandomEightByteLong() " + result);
+    return result;
+  }
+
   @Test
   public void mustReturnLongValueQueriedWithNumberLong() {
     TestLongBean longBean = new TestLongBean();
-    long randomLong = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong = generateRandomEightByteLong();
     longBean.setRandomLong(randomLong);
     testLongRepository.save(longBean);
     TestLongBean actualBean = testLongRepository.getRandomLong(randomLong);
@@ -59,11 +66,11 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Test
   public void mustReturnLongValueQueriedWithListOfNumberLong() {
     TestLongBean longBean1 = new TestLongBean();
-    long randomLong1 = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong1 = generateRandomEightByteLong();
     longBean1.setRandomLong(randomLong1);
     testLongRepository.save(longBean1);
     TestLongBean longBean2 = new TestLongBean();
-    long randomLong2 = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong2 = generateRandomEightByteLong();
     longBean2.setRandomLong(randomLong2);
     testLongRepository.save(longBean2);
 
@@ -83,7 +90,7 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Test
   public void mustAllowCombinedMatchStageAndFacet() {
     TestLongBean longBean = new TestLongBean();
-    long randomLong = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong = generateRandomEightByteLong();
     longBean.setRandomLong(randomLong);
     testLongRepository.save(longBean);
     List<TestLongBean> actualBeans = testLongRepository.queryWithALongAndFacet(Collections.singletonList(randomLong), 1);
@@ -95,7 +102,7 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Test
   public void mustAllowCombinedPlaceholdersToBeUsed() {
     TestLongBean longBean = new TestLongBean();
-    long randomLong = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong = generateRandomEightByteLong();
     String randomString = RandomStringUtils.randomAlphabetic(10);
     longBean.setRandomString(randomString);
     longBean.setRandomLong(randomLong);
@@ -108,7 +115,7 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Test
   public void mustAllowCombinedPlaceholdersToBeUsedInAnyOrder() {
     TestLongBean longBean = new TestLongBean();
-    long randomLong = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong = generateRandomEightByteLong();
     String randomString = RandomStringUtils.randomAlphabetic(10);
     longBean.setRandomString(randomString);
     longBean.setRandomLong(randomLong);
@@ -122,8 +129,8 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Test
   public void mustAllowMultipleQueryEnginePlaceholders() {
     TestLongBean longBean = new TestLongBean();
-    long randomLong = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
-    long randomLong2 = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong = generateRandomEightByteLong();
+    long randomLong2 = generateRandomEightByteLong();
 
     String randomString = RandomStringUtils.randomAlphabetic(10);
     longBean.setRandomString(randomString);
@@ -139,8 +146,8 @@ public class NumberLongTest extends AbstractTestNGSpringContextTests {
   @Test
   public void mustAllowMultipleQueryEnginePlaceholdersMixedWithSpringPlaceholders() {
     TestLongBean longBean = new TestLongBean();
-    long randomLong = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
-    long randomLong2 = RandomUtils.nextLong(System.nanoTime(), System.nanoTime() + 1000000);
+    long randomLong = generateRandomEightByteLong();
+    long randomLong2 = generateRandomEightByteLong();
 
     String randomString = RandomStringUtils.randomAlphabetic(10);
     longBean.setRandomString(randomString);


### PR DESCRIPTION
Changed the way the longs were getting generated to make sure they require a full eight bytes to represent.