### PR TITLE
Use MongoDB driver's getStrict() serializers

### DIFF
--- a/src/main/java/com/cisco/mongodb/aggregate/support/query/AbstractAggregateQueryProvider.java
+++ b/src/main/java/com/cisco/mongodb/aggregate/support/query/AbstractAggregateQueryProvider.java
@@ -28,6 +28,7 @@ import com.mongodb.DBObject;
 import com.mongodb.DBRef;
 import com.mongodb.util.JSON;
 import com.mongodb.util.JSONParseException;
+import com.mongodb.util.JSONSerializers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Condition;
@@ -198,7 +199,13 @@ public abstract class AbstractAggregateQueryProvider implements QueryProvider, I
       return (String) value;
     }
 
-    return JSON.serialize(value);
+    return serialize(value);
+  }
+
+  private static String serialize(Object object) {
+    StringBuilder buf = new StringBuilder();
+    JSONSerializers.getStrict().serialize(object, buf);
+    return buf.toString();
   }
 
   /*

--- a/src/test/java/com/cisco/mongodb/aggregate/support/test/beans/TestBinaryBean.java
+++ b/src/test/java/com/cisco/mongodb/aggregate/support/test/beans/TestBinaryBean.java
@@ -1,0 +1,48 @@
+package com.cisco.mongodb.aggregate.support.test.beans;
+
+import com.google.common.base.Objects;
+import org.jongo.marshall.jackson.oid.MongoId;
+import org.springframework.data.annotation.Id;
+
+public class TestBinaryBean {
+
+  @Id
+  @MongoId
+  private String id;
+
+  private byte[] md5Hash;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public byte[] getMd5Hash() {
+    return md5Hash;
+  }
+
+  public void setMd5Hash(byte[] md5Hash) {
+    this.md5Hash = md5Hash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TestBinaryBean binaryBean = (TestBinaryBean) o;
+    return Objects.equal(id, binaryBean.id) &&
+           Objects.equal(md5Hash, binaryBean.md5Hash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, md5Hash);
+  }
+}

--- a/src/test/java/com/cisco/mongodb/aggregate/support/test/repository/TestBinaryRepository.java
+++ b/src/test/java/com/cisco/mongodb/aggregate/support/test/repository/TestBinaryRepository.java
@@ -1,0 +1,14 @@
+package com.cisco.mongodb.aggregate.support.test.repository;
+
+import com.cisco.mongodb.aggregate.support.annotation.v2.Aggregate2;
+import com.cisco.mongodb.aggregate.support.annotation.v2.Match2;
+import com.cisco.mongodb.aggregate.support.test.beans.TestBinaryBean;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TestBinaryRepository extends MongoRepository<TestBinaryBean, String> {
+
+  @Aggregate2(name = "getByMd5Hash", inputType = TestBinaryBean.class, outputBeanType = TestBinaryBean.class)
+  @Match2(query = "{'md5Hash' : ?0}", order = 0)
+  TestBinaryBean getByMd5Hash(byte[] md5Hash);
+
+}

--- a/src/test/java/com/cisco/mongodb/aggregate/support/test/tests/BinaryDataTest.java
+++ b/src/test/java/com/cisco/mongodb/aggregate/support/test/tests/BinaryDataTest.java
@@ -1,0 +1,29 @@
+package com.cisco.mongodb.aggregate.support.test.tests;
+
+import com.cisco.mongodb.aggregate.support.test.beans.TestBinaryBean;
+import com.cisco.mongodb.aggregate.support.test.config.AggregateTestConfiguration;
+import com.cisco.mongodb.aggregate.support.test.repository.TestBinaryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.util.DigestUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@ContextConfiguration(classes = AggregateTestConfiguration.class)
+public class BinaryDataTest extends AbstractTestNGSpringContextTests {
+
+  @Autowired
+  private TestBinaryRepository testBinaryRepository;
+
+  @Test
+  public void mustReturnBinaryBeanQueriedWithMd5Hash() {
+    TestBinaryBean binaryBean = new TestBinaryBean();
+    byte[] md5Hash = DigestUtils.md5Digest(String.valueOf(System.nanoTime()).getBytes());
+    binaryBean.setMd5Hash(md5Hash);
+    testBinaryRepository.save(binaryBean);
+    TestBinaryBean actualBean = testBinaryRepository.getByMd5Hash(md5Hash);
+    Assert.assertNotNull(actualBean);
+    Assert.assertEquals(actualBean.getMd5Hash(), binaryBean.getMd5Hash());
+  }
+}


### PR DESCRIPTION
The JSON.serialize() static method always calls getLegacy() for the serializers. In MongoDB's own words:

> Clients should generally prefer `getStrict` in preference to this method.