### PR TITLE
Support for different linux versions

### DIFF
--- a/mongodb-aggregate-query-support-reactive/src/test/java/com/github/krr/mongodb/aggregate/support/config/NonReactiveMongoClientTestConfiguration.java
+++ b/mongodb-aggregate-query-support-reactive/src/test/java/com/github/krr/mongodb/aggregate/support/config/NonReactiveMongoClientTestConfiguration.java
@@ -52,6 +52,7 @@ public class NonReactiveMongoClientTestConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(NonReactiveMongoClientTestConfiguration.class);
 
   private static final String LOCALHOST = "localhost";
+  private static final String V4_2_5 = "4.2.5";
 
   private final MongodExecutable mongodExecutable;
 
@@ -69,7 +70,7 @@ public class NonReactiveMongoClientTestConfiguration {
                                                                                 .download(downloadConfig))
                                                              .build();
     final MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-    mongodExecutable = runtime.prepare(newMongodConfig(MongoDbVersion.V4_2_4));
+    mongodExecutable = runtime.prepare(newMongodConfig(new MongoDbVersion(V4_2_5)));
     startMongodExecutable();
   }
 

--- a/mongodb-aggregate-query-support-reactive/src/test/java/com/github/krr/mongodb/aggregate/support/config/ReactiveMongoClientTestConfiguration.java
+++ b/mongodb-aggregate-query-support-reactive/src/test/java/com/github/krr/mongodb/aggregate/support/config/ReactiveMongoClientTestConfiguration.java
@@ -58,6 +58,7 @@ public class ReactiveMongoClientTestConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveMongoClientTestConfiguration.class);
 
   private static final String LOCALHOST = "localhost";
+  private static final String V4_2_5 = "4.2.5";
 
   private final MongodExecutable mongodExecutable;
 
@@ -75,7 +76,7 @@ public class ReactiveMongoClientTestConfiguration {
                                                                                 .download(downloadConfig))
                                                              .build();
     final MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-    mongodExecutable = runtime.prepare(newMongodConfig(MongoDbVersion.V4_2_4));
+    mongodExecutable = runtime.prepare(newMongodConfig(new MongoDbVersion(V4_2_5)));
     startMongodExecutable();
   }
 

--- a/mongodb-aggregate-query-support-spring4/src/test/java/com/github/krr/mongodb/aggregate/support/config/MongoClientTestConfiguration.java
+++ b/mongodb-aggregate-query-support-spring4/src/test/java/com/github/krr/mongodb/aggregate/support/config/MongoClientTestConfiguration.java
@@ -57,6 +57,7 @@ public class MongoClientTestConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoClientTestConfiguration.class);
 
   private static final String LOCALHOST = "localhost";
+  private static final String V4_2_5 = "4.2.5";
 
   private final MongodExecutable mongodExecutable;
 
@@ -74,7 +75,7 @@ public class MongoClientTestConfiguration {
                                                                                 .download(downloadConfig))
                                                              .build();
     final MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-    mongodExecutable = runtime.prepare(newMongodConfig(MongoDbVersion.V4_2_4));
+    mongodExecutable = runtime.prepare(newMongodConfig(new MongoDbVersion(V4_2_5)));
     startMongodExecutable();
   }
 

--- a/mongodb-aggregate-query-support-test/pom.xml
+++ b/mongodb-aggregate-query-support-test/pom.xml
@@ -17,5 +17,11 @@
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.14.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReader.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReader.java
@@ -13,65 +13,80 @@ import java.util.Scanner;
 
 @Slf4j
 public class LinuxDistributionReader {
-  public static String getLinuxVersion() {
+  private static final String CENTOS = "centos";
+  private static final String RHEL = "rhel";
+  private static final String REDHAT = "redhat";
+  private static final String RED_HAT = "red hat";
+  private static final String UBUNTU = "ubuntu";
+  public static final String VERSION_ID = "VERSION_ID";
+  public static final String ID = "ID";
+  public static final String UBUNTU_1604 = "ubuntu1604";
+  public static final String UBUNTU_1804 = "ubuntu1804";
+  public static final String RHEL_62 = "rhel62";
+  public static final String RHEL_70 = "rhel70";
+  public static final String RHEL_80 = "rhel80";
+
+  public String getLinuxVersion() {
     Map.Entry<String, String> distro = getLinuxDistro();
     String distribution = distro.getKey();
     String version = distro.getValue();
     if (distribution.isEmpty() || version.isEmpty()) {
-      log.error("Error in parsing through os release files to fetch linux distribution and version");
-      return "";
+      log.error("Failed to fetch linux distribution information");
+      throw new RuntimeException("Unable to extract linux distribution information." +
+                                 " You might need to consider upgrading your linux distribution.");
     }
     switch (distribution.toLowerCase()) {
-      case "ubuntu":
+      case UBUNTU:
         return getUbuntuVersion(version);
-      case "centos":
-      case "rhel":
+      case CENTOS:
+      case RHEL:
         return getRedHatVersion(version);
       default:
         // This distribution id isn't supported by mongo
-        log.error("The current linux belongs to {} and isn't supported", distribution);
-        return "";
+        log.error("Current linux distribution belongs to {}, which isn't supported", distribution);
+        throw new RuntimeException(
+            String.format("Linux %s isn't supported, please contact support", distribution));
     }
   }
 
-  private static String getRedHatVersion(String version) {
+  private String getRedHatVersion(String version) {
     int versionId = (int) Double.parseDouble(version);
     if (versionId <= 6) {
-      return "rhel62";
+      return RHEL_62;
     }
     else if (versionId == 7) {
-      return "rhel70";
+      return RHEL_70;
     }
     else if (versionId == 8) {
-      return "rhel80";
+      return RHEL_80;
     }
     else {
       // As of this commit, mongo only supports CentOS 6.2+.
       // Update the ubuntu version link for later versions here
-      log.error("Red Hat {} isn't supported, please contact support", version);
-      return "";
+      log.error("Red Hat {} isn't supported", version);
+      throw new RuntimeException(String.format("Red Hat %s isn't supported, please contact support", version));
     }
   }
 
-  private static String getUbuntuVersion(String version) {
+  private String getUbuntuVersion(String version) {
     int versionId = (int) Double.parseDouble(version);
     if (versionId <= 16) {
-      return "ubuntu1604";
+      return UBUNTU_1604;
     }
     else if (versionId == 18) {
-      return "ubuntu1804";
+      return UBUNTU_1804;
     }
     else {
       // As of this commit, mongo only supports Ubuntu-16.04 and Ubuntu-18-04.
       // Update the ubuntu version link for later versions here
-      log.error("Ubuntu {} isn't supported, please contact support", version);
-      return "";
+      log.error("Ubuntu {} isn't supported", version);
+      throw new RuntimeException(String.format("Ubuntu %s isn't supported, please contact support", version));
     }
   }
 
-  private static Map.Entry<String, String> getLinuxDistro() {
-    if("ubuntu1604".equals(System.getenv("OS_DIST"))){
-      return new AbstractMap.SimpleEntry<>("ubuntu", "16.04");
+  private Map.Entry<String, String> getLinuxDistro() {
+    if (UBUNTU_1604.equals(System.getenv("OS_DIST"))) {
+      return new AbstractMap.SimpleEntry<>(UBUNTU, "16.04");
     }
     File fileVersion = new File("/etc/os-release");
     if (fileVersion.exists()) {
@@ -85,19 +100,21 @@ public class LinuxDistributionReader {
     if (fileVersion.exists()) {
       return getRedHatRelease(fileVersion);
     }
-    return new AbstractMap.SimpleEntry<>("", "");
+    log.error("Failed to fetch linux distribution information");
+    throw new RuntimeException("Unable to extract linux distribution information." +
+                               " You might need to consider upgrading your linux distribution.");
   }
 
-  private static AbstractMap.SimpleEntry<String, String> getRedHatRelease(File fileVersion) {
+  private AbstractMap.SimpleEntry<String, String> getRedHatRelease(File fileVersion) {
     String distribution = "", version = "";
     ArrayList<String> fileContents = readFile(fileVersion);
     for (String line : fileContents) {
-      if (!line.isEmpty() && (line.toLowerCase().contains("centos") || line.toLowerCase().contains("redhat")
-                              || line.toLowerCase().contains("red hat"))) {
-        distribution = "rhel";
+      if (!line.isEmpty() && (line.toLowerCase().contains(CENTOS) || line.toLowerCase().contains(REDHAT)
+                              || line.toLowerCase().contains(RED_HAT))) {
+        distribution = RHEL;
         Scanner scan = new Scanner(line);
         while (scan.hasNext()) {
-          if(scan.hasNextDouble()) {
+          if (scan.hasNextDouble()) {
             version = String.valueOf(scan.nextDouble());
             // Return the first number read as the version number
             return new AbstractMap.SimpleEntry<>(distribution, version);
@@ -111,31 +128,30 @@ public class LinuxDistributionReader {
     return new AbstractMap.SimpleEntry<>(distribution, version);
   }
 
-  private static Map.Entry<String, String> getOsRelease(File fileVersion) {
+  private Map.Entry<String, String> getOsRelease(File fileVersion) {
     String distribution = "", version = "";
     ArrayList<String> fileContents = readFile(fileVersion);
     for (String line : fileContents) {
       String[] properties = line.split("=");
-      if ("ID".equals(properties[0])) {
+      if (ID.equals(properties[0])) {
         distribution = properties[1];
       }
-      else if ("VERSION_ID".equals(properties[0])) {
+      else if (VERSION_ID.equals(properties[0])) {
         version = properties[1];
       }
     }
     return new AbstractMap.SimpleEntry<>(distribution, version);
   }
 
-  private static ArrayList<String> readFile(File file) {
+  private ArrayList<String> readFile(File file) {
     ArrayList<String> fileContents = new ArrayList<>();
-    try {
-      BufferedReader bufferedReader = new BufferedReader(new FileReader(file));
+    try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
       while (bufferedReader.ready()) {
         fileContents.add(bufferedReader.readLine());
       }
     }
     catch (IOException e) {
-      log.error("Error reading file {}", file.getName(), e);
+      log.error("Error reading the file {}", file.getName(), e);
     }
     return fileContents;
   }

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReader.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReader.java
@@ -1,0 +1,142 @@
+package com.github.krr.mongodb.embeddedmongo.config;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Scanner;
+
+@Slf4j
+public class LinuxDistributionReader {
+  public static String getLinuxVersion() {
+    Map.Entry<String, String> distro = getLinuxDistro();
+    String distribution = distro.getKey();
+    String version = distro.getValue();
+    if (distribution.isEmpty() || version.isEmpty()) {
+      log.error("Error in parsing through os release files to fetch linux distribution and version");
+      return "";
+    }
+    switch (distribution.toLowerCase()) {
+      case "ubuntu":
+        return getUbuntuVersion(version);
+      case "centos":
+      case "rhel":
+        return getRedHatVersion(version);
+      default:
+        // This distribution id isn't supported by mongo
+        log.error("The current linux belongs to {} and isn't supported", distribution);
+        return "";
+    }
+  }
+
+  private static String getRedHatVersion(String version) {
+    int versionId = (int) Double.parseDouble(version);
+    if (versionId <= 6) {
+      return "rhel62";
+    }
+    else if (versionId == 7) {
+      return "rhel70";
+    }
+    else if (versionId == 8) {
+      return "rhel80";
+    }
+    else {
+      // As of this commit, mongo only supports CentOS 6.2+.
+      // Update the ubuntu version link for later versions here
+      log.error("Red Hat {} isn't supported, please contact support", version);
+      return "";
+    }
+  }
+
+  private static String getUbuntuVersion(String version) {
+    int versionId = (int) Double.parseDouble(version);
+    if (versionId <= 16) {
+      return "ubuntu1604";
+    }
+    else if (versionId == 18) {
+      return "ubuntu1804";
+    }
+    else {
+      // As of this commit, mongo only supports Ubuntu-16.04 and Ubuntu-18-04.
+      // Update the ubuntu version link for later versions here
+      log.error("Ubuntu {} isn't supported, please contact support", version);
+      return "";
+    }
+  }
+
+  private static Map.Entry<String, String> getLinuxDistro() {
+    if("ubuntu1604".equals(System.getenv("OS_DIST"))){
+      return new AbstractMap.SimpleEntry<>("ubuntu", "16.04");
+    }
+    File fileVersion = new File("/etc/os-release");
+    if (fileVersion.exists()) {
+      return getOsRelease(fileVersion);
+    }
+    fileVersion = new File("/etc/redhat-release");
+    if (fileVersion.exists()) {
+      return getRedHatRelease(fileVersion);
+    }
+    fileVersion = new File("/etc/centos-release");
+    if (fileVersion.exists()) {
+      return getRedHatRelease(fileVersion);
+    }
+    return new AbstractMap.SimpleEntry<>("", "");
+  }
+
+  private static AbstractMap.SimpleEntry<String, String> getRedHatRelease(File fileVersion) {
+    String distribution = "", version = "";
+    ArrayList<String> fileContents = readFile(fileVersion);
+    for (String line : fileContents) {
+      if (!line.isEmpty() && (line.toLowerCase().contains("centos") || line.toLowerCase().contains("redhat")
+                              || line.toLowerCase().contains("red hat"))) {
+        distribution = "rhel";
+        Scanner scan = new Scanner(line);
+        while (scan.hasNext()) {
+          if(scan.hasNextDouble()) {
+            version = String.valueOf(scan.nextDouble());
+            // Return the first number read as the version number
+            return new AbstractMap.SimpleEntry<>(distribution, version);
+          }
+          else {
+            scan.next();
+          }
+        }
+      }
+    }
+    return new AbstractMap.SimpleEntry<>(distribution, version);
+  }
+
+  private static Map.Entry<String, String> getOsRelease(File fileVersion) {
+    String distribution = "", version = "";
+    ArrayList<String> fileContents = readFile(fileVersion);
+    for (String line : fileContents) {
+      String[] properties = line.split("=");
+      if ("ID".equals(properties[0])) {
+        distribution = properties[1];
+      }
+      else if ("VERSION_ID".equals(properties[0])) {
+        version = properties[1];
+      }
+    }
+    return new AbstractMap.SimpleEntry<>(distribution, version);
+  }
+
+  private static ArrayList<String> readFile(File file) {
+    ArrayList<String> fileContents = new ArrayList<>();
+    try {
+      BufferedReader bufferedReader = new BufferedReader(new FileReader(file));
+      while (bufferedReader.ready()) {
+        fileContents.add(bufferedReader.readLine());
+      }
+    }
+    catch (IOException e) {
+      log.error("Error reading file {}", file.getName(), e);
+    }
+    return fileContents;
+  }
+}

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReader.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReader.java
@@ -4,10 +4,7 @@ import com.github.krr.mongodb.embeddedmongo.config.impl.LinuxPackageIoUtil;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Scanner;
+import java.util.*;
 
 @Slf4j
 public class LinuxDistributionReader {
@@ -24,6 +21,9 @@ public class LinuxDistributionReader {
   public static final String RHEL_80 = "rhel80";
   public static final String OS_DIST = "OS_DIST";
   public static final String V16_04 = "16.04";
+  public static final String ETC_OS_RELEASE = "/etc/os-release";
+  public static final String ETC_REDHAT_RELEASE = "/etc/redhat-release";
+  public static final String ETC_CENTOS_RELEASE = "/etc/centos-release";
 
   private final LinuxPackageIoUtil linuxPackageIoUtil;
 
@@ -93,15 +93,15 @@ public class LinuxDistributionReader {
     if (UBUNTU_1604.equals(linuxPackageIoUtil.getEnv(OS_DIST))) {
       return new AbstractMap.SimpleEntry<>(UBUNTU, V16_04);
     }
-    File fileVersion = new File("/etc/os-release");
+    File fileVersion = new File(ETC_OS_RELEASE);
     if (linuxPackageIoUtil.isExists(fileVersion)) {
       return getOsRelease(fileVersion);
     }
-    fileVersion = new File("/etc/redhat-release");
+    fileVersion = new File(ETC_REDHAT_RELEASE);
     if (linuxPackageIoUtil.isExists(fileVersion)) {
       return getRedHatRelease(fileVersion);
     }
-    fileVersion = new File("/etc/centos-release");
+    fileVersion = new File(ETC_CENTOS_RELEASE);
     if (linuxPackageIoUtil.isExists(fileVersion)) {
       return getRedHatRelease(fileVersion);
     }
@@ -110,9 +110,9 @@ public class LinuxDistributionReader {
                                " You might need to consider upgrading your linux distribution.");
   }
 
-  private AbstractMap.SimpleEntry<String, String> getRedHatRelease(File fileVersion) {
+  private Map.Entry<String, String> getRedHatRelease(File fileVersion) {
     String distribution = "", version = "";
-    ArrayList<String> fileContents = linuxPackageIoUtil.readFile(fileVersion);
+    List<String> fileContents = linuxPackageIoUtil.readFile(fileVersion);
     for (String line : fileContents) {
       if (!line.isEmpty() && (line.toLowerCase().contains(CENTOS) || line.toLowerCase().contains(RED_HAT))) {
         distribution = RHEL;
@@ -134,7 +134,7 @@ public class LinuxDistributionReader {
 
   private Map.Entry<String, String> getOsRelease(File fileVersion) {
     String distribution = "", version = "";
-    ArrayList<String> fileContents = linuxPackageIoUtil.readFile(fileVersion);
+    List<String> fileContents = linuxPackageIoUtil.readFile(fileVersion);
     for (String line : fileContents) {
       String[] properties = line.split("=");
       if (ID.equals(properties[0])) {

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxPackageIoUtilImpl.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxPackageIoUtilImpl.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 public class LinuxPackageIoUtilImpl implements LinuxPackageIoUtil {
@@ -17,8 +18,8 @@ public class LinuxPackageIoUtilImpl implements LinuxPackageIoUtil {
   }
 
   @Override
-  public ArrayList<String> readFile(File file) {
-    ArrayList<String> fileContents = new ArrayList<>();
+  public List<String> readFile(File file) {
+    List<String> fileContents = new ArrayList<>();
     try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
       while (bufferedReader.ready()) {
         fileContents.add(bufferedReader.readLine());

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxPackageIoUtilImpl.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/LinuxPackageIoUtilImpl.java
@@ -1,0 +1,37 @@
+package com.github.krr.mongodb.embeddedmongo.config;
+
+import com.github.krr.mongodb.embeddedmongo.config.impl.LinuxPackageIoUtil;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+
+@Slf4j
+public class LinuxPackageIoUtilImpl implements LinuxPackageIoUtil {
+  @Override
+  public boolean isExists(File file) {
+    return file.exists();
+  }
+
+  @Override
+  public ArrayList<String> readFile(File file) {
+    ArrayList<String> fileContents = new ArrayList<>();
+    try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
+      while (bufferedReader.ready()) {
+        fileContents.add(bufferedReader.readLine());
+      }
+    }
+    catch (IOException e) {
+      log.error("Error reading the file {}", file.getName(), e);
+    }
+    return fileContents;
+  }
+
+  @Override
+  public String getEnv(String property) {
+    return System.getenv(property);
+  }
+}

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
@@ -14,8 +14,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Mongo42xPaths extends Paths {
 
+  private final LinuxPackageIoUtilImpl linuxPackageIoUtil;
+
   public Mongo42xPaths(Command command) {
     super(command);
+    this.linuxPackageIoUtil = new LinuxPackageIoUtilImpl();
   }
 
   @Override
@@ -45,7 +48,7 @@ public class Mongo42xPaths extends Paths {
       return platformStr + "/mongodb-macos" + "-" + bitSizeStr + "-" + versionStr + "." + archiveTypeStr;
     }
     else if (distribution.getPlatform() == Platform.Linux) {
-      String linuxVersion = new LinuxDistributionReader().getLinuxVersion();
+      String linuxVersion = new LinuxDistributionReader(linuxPackageIoUtil).getLinuxVersion();
       return platformStr + "/mongodb-" + platformStr + "-" + bitSizeStr + "-" + linuxVersion + "-" + versionStr + "." +
              archiveTypeStr;
     }

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
@@ -34,23 +34,21 @@ public class Mongo42xPaths extends Paths {
     String bitSizeStr = getBitSize(distribution);
 
     if ((distribution.getBitsize() == BitSize.B64) && (distribution.getPlatform() == Platform.Windows)) {
-      versionStr = (useWindows2008PlusVersion(distribution) ? "2008plus-": "")
-                   + (withSsl(distribution) ? "ssl-": "")
+      versionStr = (useWindows2008PlusVersion(distribution) ? "2008plus-" : "") + (withSsl(distribution) ? "ssl-" : "")
                    + versionStr;
     }
-    if (distribution.getPlatform() == Platform.OS_X && withSsl(distribution) ) {
+    if (distribution.getPlatform() == Platform.OS_X && withSsl(distribution)) {
       return platformStr + "/mongodb-macos" + "-ssl-" + bitSizeStr + "-" + versionStr + "." + archiveTypeStr;
     }
-    else if(distribution.getPlatform() == Platform.OS_X && !withSsl(distribution) ) {
+    else if (distribution.getPlatform() == Platform.OS_X) {
+      // withSsl(distribution) = false
       return platformStr + "/mongodb-macos" + "-" + bitSizeStr + "-" + versionStr + "." + archiveTypeStr;
     }
-    else {
-      String osDist = System.getenv("OS_DIST");
-      if(distribution.getPlatform() == Platform.Linux && "ubuntu1604".equalsIgnoreCase(osDist)) {
-        // right now build this for travisci
-        //http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.4.tgz
-        log.error("Downloading Mongo {} for Ubuntu 16.04", versionStr);
-        return "linux/mongodb-linux-x86_64-ubuntu1604-" + versionStr + "." + archiveTypeStr;
+    else if (distribution.getPlatform() == Platform.Linux) {
+      String linuxVersion = LinuxDistributionReader.getLinuxVersion();
+      if (!linuxVersion.isEmpty()) {
+        return platformStr + "/mongodb-" + platformStr + "-" + bitSizeStr + "-" + linuxVersion + "-" + versionStr +
+               "." + archiveTypeStr;
       }
     }
     return super.getPath(distribution);
@@ -59,7 +57,7 @@ public class Mongo42xPaths extends Paths {
   @SuppressWarnings("SameParameterValue")
   private static boolean isFeatureEnabled(Distribution distribution, Feature feature) {
     return (distribution.getVersion() instanceof IFeatureAwareVersion
-            &&  ((IFeatureAwareVersion) distribution.getVersion()).enabled(feature));
+            && ((IFeatureAwareVersion) distribution.getVersion()).enabled(feature));
   }
 
   private String getArchiveString(ArchiveType archiveType) {
@@ -108,7 +106,7 @@ public class Mongo42xPaths extends Paths {
         if (distribution.getVersion() instanceof IFeatureAwareVersion) {
           IFeatureAwareVersion featuredVersion = (IFeatureAwareVersion) distribution.getVersion();
           if (featuredVersion.enabled(Feature.ONLY_64BIT)) {
-            throw new IllegalArgumentException("this version does not support 32Bit: "+distribution);
+            throw new IllegalArgumentException("this version does not support 32Bit: " + distribution);
           }
         }
 
@@ -121,7 +119,8 @@ public class Mongo42xPaths extends Paths {
             sbitSize = "i386";
             break;
           default:
-            throw new IllegalArgumentException("Platform " + distribution.getPlatform() + " not supported yet on 32Bit Platform");
+            throw new IllegalArgumentException(
+                "Platform " + distribution.getPlatform() + " not supported yet on 32Bit Platform");
         }
         break;
       case B64:

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
@@ -49,14 +49,12 @@ public class Mongo42xPaths extends Paths {
       if(distribution.getPlatform() == Platform.Linux && "ubuntu1604".equalsIgnoreCase(osDist)) {
         // right now build this for travisci
         //http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.4.tgz
-        log.error("Downloading Mongo 4.2.4 for Ubuntu 16.04");
-        return "linux/mongodb-linux-x86_64-ubuntu1604-4.2.4.tgz";
-
+        log.error("Downloading Mongo {} for Ubuntu 16.04", versionStr);
+        return "linux/mongodb-linux-x86_64-ubuntu1604-" + versionStr + "." + archiveTypeStr;
       }
     }
     return super.getPath(distribution);
   }
-  //
 
   @SuppressWarnings("SameParameterValue")
   private static boolean isFeatureEnabled(Distribution distribution, Feature feature) {

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/Mongo42xPaths.java
@@ -45,11 +45,9 @@ public class Mongo42xPaths extends Paths {
       return platformStr + "/mongodb-macos" + "-" + bitSizeStr + "-" + versionStr + "." + archiveTypeStr;
     }
     else if (distribution.getPlatform() == Platform.Linux) {
-      String linuxVersion = LinuxDistributionReader.getLinuxVersion();
-      if (!linuxVersion.isEmpty()) {
-        return platformStr + "/mongodb-" + platformStr + "-" + bitSizeStr + "-" + linuxVersion + "-" + versionStr +
-               "." + archiveTypeStr;
-      }
+      String linuxVersion = new LinuxDistributionReader().getLinuxVersion();
+      return platformStr + "/mongodb-" + platformStr + "-" + bitSizeStr + "-" + linuxVersion + "-" + versionStr + "." +
+             archiveTypeStr;
     }
     return super.getPath(distribution);
   }

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/MongoDbVersion.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/MongoDbVersion.java
@@ -4,27 +4,31 @@ import de.flapdoodle.embed.mongo.distribution.Feature;
 import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 
 @Slf4j
-public enum MongoDbVersion implements IFeatureAwareVersion {
-
-  V4_2_4("4.2.4", Feature.SYNC_DELAY, Feature.STORAGE_ENGINE, Feature.ONLY_64BIT, Feature.NO_CHUNKSIZE_ARG,
-         Feature.MONGOS_CONFIGDB_SET_STYLE, Feature.NO_HTTP_INTERFACE_ARG,
-         Feature.ONLY_WINDOWS_2008_SERVER, Feature.NO_SOLARIS_SUPPORT, Feature.NO_BIND_IP_TO_LOCALHOST)
-
-//  V4_2_2("4.2.2", Feature.SYNC_DELAY, Feature.STORAGE_ENGINE, Feature.ONLY_64BIT, Feature.NO_CHUNKSIZE_ARG, Feature.NO_NOPREALLOC_ARG, Feature.NO_SMALLFILES_ARG, Feature.MONGOS_CONFIGDB_SET_STYLE, Feature.NO_HTTP_INTERFACE_ARG, Feature.ONLY_WINDOWS_2012_SERVER, Feature.NO_SOLARIS_SUPPORT, Feature.NO_GENERIC_LINUX, Feature.NO_BIND_IP_TO_LOCALHOST),
-
-      ;
-
-
+public class MongoDbVersion implements IFeatureAwareVersion {
   private final String specificVersion;
+  private final EnumSet<Feature> features;
+  private static final Feature[] DEFAULT_42x_FEATURES = (Feature[]) Arrays.asList(Feature.SYNC_DELAY,
+                                                                                  Feature.STORAGE_ENGINE,
+                                                                                  Feature.ONLY_64BIT,
+                                                                                  Feature.NO_CHUNKSIZE_ARG,
+                                                                                  Feature.MONGOS_CONFIGDB_SET_STYLE,
+                                                                                  Feature.NO_HTTP_INTERFACE_ARG,
+                                                                                  Feature.ONLY_WINDOWS_2008_SERVER,
+                                                                                  Feature.NO_SOLARIS_SUPPORT,
+                                                                                  Feature.NO_BIND_IP_TO_LOCALHOST)
+                                                                          .toArray();
 
-  private EnumSet<Feature> features;
-
-  MongoDbVersion(String vName, Feature... features) {
+  public MongoDbVersion(String vName, Feature... features) {
     this.specificVersion = vName;
     this.features = Feature.asSet(features);
+  }
+
+  public MongoDbVersion(String vName) {
+    this(vName, DEFAULT_42x_FEATURES);
   }
 
   @Override
@@ -46,5 +50,4 @@ public enum MongoDbVersion implements IFeatureAwareVersion {
   public String toString() {
     return "MongoDbVersion{" + specificVersion + '}';
   }
-
 }

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/impl/LinuxPackageIoUtil.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/impl/LinuxPackageIoUtil.java
@@ -1,10 +1,10 @@
 package com.github.krr.mongodb.embeddedmongo.config.impl;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.List;
 
 public interface LinuxPackageIoUtil {
   boolean isExists(File file);
-  ArrayList<String> readFile(File file);
+  List<String> readFile(File file);
   String getEnv(String property);
 }

--- a/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/impl/LinuxPackageIoUtil.java
+++ b/mongodb-aggregate-query-support-test/src/main/java/com/github/krr/mongodb/embeddedmongo/config/impl/LinuxPackageIoUtil.java
@@ -1,0 +1,10 @@
+package com.github.krr.mongodb.embeddedmongo.config.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+
+public interface LinuxPackageIoUtil {
+  boolean isExists(File file);
+  ArrayList<String> readFile(File file);
+  String getEnv(String property);
+}

--- a/mongodb-aggregate-query-support-test/src/main/resources/log4j2.xml
+++ b/mongodb-aggregate-query-support-test/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="com.github.krr.mongodb.embeddedmongo.config" level="error">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/mongodb-aggregate-query-support-test/src/test/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReaderTest.java
+++ b/mongodb-aggregate-query-support-test/src/test/java/com/github/krr/mongodb/embeddedmongo/config/LinuxDistributionReaderTest.java
@@ -1,0 +1,203 @@
+package com.github.krr.mongodb.embeddedmongo.config;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static com.github.krr.mongodb.embeddedmongo.config.LinuxDistributionReader.*;
+
+public class LinuxDistributionReaderTest {
+  private LinuxDistributionReader linuxDistributionReader;
+  private TestLinuxPackageIoUtil linuxPackageIoUtil;
+
+  @BeforeMethod
+  public void setUp() {
+    linuxPackageIoUtil = new TestLinuxPackageIoUtil();
+    linuxDistributionReader = new LinuxDistributionReader(linuxPackageIoUtil);
+  }
+
+  ///////TESTS///////
+
+  @Test
+  public void testTravisCiVersion() {
+    linuxPackageIoUtil.setOsDistEnv(UBUNTU_1604);
+    Assert.assertEquals(UBUNTU_1604, linuxDistributionReader.getLinuxVersion());
+  }
+
+  @Test(dataProvider = "testOsReleaseFixture", invocationCount = 5)
+  public void testOsRelease(String distribution, String version, String versionLink) {
+    linuxPackageIoUtil.setOsReleaseId(distribution);
+    linuxPackageIoUtil.setOsReleaseVersionId(version);
+    linuxPackageIoUtil.setOsRelease(true);
+    Assert.assertEquals(versionLink, linuxDistributionReader.getLinuxVersion());
+  }
+
+  @Test(dataProvider = "testRedHatReleaseFixture", invocationCount = 5)
+  public void testRedHatRelease(String content, String versionLink) {
+    linuxPackageIoUtil.setOsRedHatReleaseContent(content);
+    linuxPackageIoUtil.setOsRedHatRelease(true);
+    Assert.assertEquals(versionLink, linuxDistributionReader.getLinuxVersion());
+  }
+
+  @Test(dataProvider = "testCentOsReleaseFixture", invocationCount = 5)
+  public void testCentOsRelease(String content, String versionLink) {
+    linuxPackageIoUtil.setOsCentOsReleaseContent(content);
+    linuxPackageIoUtil.setOsCentOsRelease(true);
+    Assert.assertEquals(versionLink, linuxDistributionReader.getLinuxVersion());
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testUnkownDistribution() {
+    // Fail to fetch linux distribution information
+    linuxDistributionReader.getLinuxVersion();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, dataProvider = "testOsInvalidReleaseFixture", invocationCount = 5)
+  public void testInvalidVersion(String distribution, String version) {
+    // linux version is unsupported
+    linuxPackageIoUtil.setOsRelease(true);
+    linuxPackageIoUtil.setOsReleaseId(distribution);
+    linuxPackageIoUtil.setOsReleaseVersionId(version);
+    linuxDistributionReader.getLinuxVersion();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testCorruptedOsRelease() {
+    // os-release file doesn't have ID or VERSION_ID fields
+    linuxPackageIoUtil.setOsRelease(true);
+    linuxPackageIoUtil.setOsReleaseId(RandomStringUtils.randomAlphabetic(5));
+    linuxPackageIoUtil.setOsReleaseVersionId(RandomStringUtils.randomNumeric(3));
+    linuxDistributionReader.getLinuxVersion();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testCorruptedRedHatRelease() {
+    // redhat-release file doesn't have version info
+    linuxPackageIoUtil.setOsRedHatRelease(true);
+    linuxPackageIoUtil.setOsRedHatReleaseContent(RandomStringUtils.randomAlphanumeric(20));
+    linuxDistributionReader.getLinuxVersion();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testCorruptedCentOsRelease() {
+    // centos-release file doesn't have version info
+    linuxPackageIoUtil.setOsCentOsRelease(true);
+    linuxPackageIoUtil.setOsCentOsReleaseContent(RandomStringUtils.randomAlphanumeric(20));
+    linuxDistributionReader.getLinuxVersion();
+  }
+
+  ///////DATA FIXTURES///////
+
+  @DataProvider
+  public Object[][] testRedHatReleaseFixture() {
+    String version, distroContent = "Red Hat Enterprise Linux Server release ";
+    StringBuilder versionLink = new StringBuilder(RHEL);
+    switch (RandomUtils.nextInt(0, 3)) {
+      case 0:
+        version = "6.2";
+        versionLink.append("62");
+        break;
+      case 1:
+        version = "7.0";
+        versionLink.append("70");
+        break;
+      default:
+        version = "8.0";
+        versionLink.append("80");
+    }
+    return new Object[][]{
+        new Object[]{distroContent.concat(version), versionLink.toString()}
+    };
+  }
+
+  @DataProvider
+  public Object[][] testCentOsReleaseFixture() {
+    String version, distroContent = "CentOS release ";
+    StringBuilder versionLink = new StringBuilder(RHEL);
+    switch (RandomUtils.nextInt(0, 3)) {
+      case 0:
+        version = "6.2";
+        versionLink.append("62");
+        break;
+      case 1:
+        version = "7.0";
+        versionLink.append("70");
+        break;
+      default:
+        version = "8.0";
+        versionLink.append("80");
+    }
+    return new Object[][]{
+        new Object[]{distroContent.concat(version), versionLink.toString()}
+    };
+  }
+
+  @DataProvider
+  public Object[][] testOsReleaseFixture() {
+    String distribution = "", version;
+    StringBuilder versionLink = new StringBuilder();
+    switch (RandomUtils.nextInt(0, 3)) {
+      case 0:
+        distribution = UBUNTU;
+        versionLink.append(UBUNTU);
+        if (RandomUtils.nextBoolean()) {
+          version = "16.04";
+          versionLink.append("1604");
+        }
+        else {
+          version = "18.04";
+          versionLink.append("1804");
+        }
+        break;
+      case 1:
+        distribution = RHEL;
+        versionLink.append(RHEL);
+      default:
+        if (distribution.isEmpty()) {
+          distribution = CENTOS;
+          versionLink.append(RHEL);
+        }
+        switch (RandomUtils.nextInt(0, 3)) {
+          case 0:
+            version = "6.2";
+            versionLink.append("62");
+            break;
+          case 1:
+            version = "7.0";
+            versionLink.append("70");
+            break;
+          default:
+            version = "8.0";
+            versionLink.append("80");
+        }
+    }
+    return new Object[][]{
+        new Object[]{distribution, version, versionLink.toString()}
+    };
+  }
+
+  @DataProvider
+  public Object[][] testOsInvalidReleaseFixture() {
+    String distribution = "", version;
+    switch (RandomUtils.nextInt(0, 3)) {
+      case 0:
+        distribution = UBUNTU;
+        version = "20.04";
+        break;
+      case 1:
+        distribution = RHEL;
+      default:
+        if (distribution.isEmpty()) {
+          distribution = CENTOS;
+        }
+        version = "9.0";
+    }
+    return new Object[][]{
+        new Object[]{distribution, version}
+    };
+  }
+
+}

--- a/mongodb-aggregate-query-support-test/src/test/java/com/github/krr/mongodb/embeddedmongo/config/TestLinuxPackageIoUtil.java
+++ b/mongodb-aggregate-query-support-test/src/test/java/com/github/krr/mongodb/embeddedmongo/config/TestLinuxPackageIoUtil.java
@@ -5,6 +5,7 @@ import lombok.Data;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 import static com.github.krr.mongodb.embeddedmongo.config.LinuxDistributionReader.*;
 
@@ -21,29 +22,29 @@ public class TestLinuxPackageIoUtil implements LinuxPackageIoUtil {
 
   @Override
   public boolean isExists(File file) {
-    if("/etc/os-release".equals(file.getAbsolutePath())) {
+    if(ETC_OS_RELEASE.equals(file.getAbsolutePath())) {
       return isOsRelease;
     }
-    else if ("/etc/redhat-release".equals(file.getAbsolutePath())){
+    else if (ETC_REDHAT_RELEASE.equals(file.getAbsolutePath())){
       return isOsRedHatRelease;
     }
-    else if ("/etc/centos-release".equals(file.getAbsolutePath())){
+    else if (ETC_CENTOS_RELEASE.equals(file.getAbsolutePath())){
       return isOsCentOsRelease;
     }
     return false;
   }
 
   @Override
-  public ArrayList<String> readFile(File file) {
-    ArrayList<String> result = new ArrayList<>();
-    if("/etc/os-release".equals(file.getAbsolutePath())) {
+  public List<String> readFile(File file) {
+    List<String> result = new ArrayList<>();
+    if(ETC_OS_RELEASE.equals(file.getAbsolutePath())) {
       result.add(ID.concat("=").concat(osReleaseId));
       result.add(VERSION_ID.concat("=").concat(osReleaseVersionId));
     }
-    else if ("/etc/redhat-release".equals(file.getAbsolutePath())){
+    else if (ETC_REDHAT_RELEASE.equals(file.getAbsolutePath())){
       result.add(osRedHatReleaseContent);
     }
-    else if ("/etc/centos-release".equals(file.getAbsolutePath())){
+    else if (ETC_CENTOS_RELEASE.equals(file.getAbsolutePath())){
       result.add(osCentOsReleaseContent);
     }
     return result;

--- a/mongodb-aggregate-query-support-test/src/test/java/com/github/krr/mongodb/embeddedmongo/config/TestLinuxPackageIoUtil.java
+++ b/mongodb-aggregate-query-support-test/src/test/java/com/github/krr/mongodb/embeddedmongo/config/TestLinuxPackageIoUtil.java
@@ -1,0 +1,56 @@
+package com.github.krr.mongodb.embeddedmongo.config;
+
+import com.github.krr.mongodb.embeddedmongo.config.impl.LinuxPackageIoUtil;
+import lombok.Data;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import static com.github.krr.mongodb.embeddedmongo.config.LinuxDistributionReader.*;
+
+@Data
+public class TestLinuxPackageIoUtil implements LinuxPackageIoUtil {
+  private boolean isOsRelease;
+  private boolean isOsRedHatRelease;
+  private boolean isOsCentOsRelease;
+  private String osDistEnv;
+  private String osReleaseId;
+  private String osReleaseVersionId;
+  private String osRedHatReleaseContent;
+  private String osCentOsReleaseContent;
+
+  @Override
+  public boolean isExists(File file) {
+    if("/etc/os-release".equals(file.getAbsolutePath())) {
+      return isOsRelease;
+    }
+    else if ("/etc/redhat-release".equals(file.getAbsolutePath())){
+      return isOsRedHatRelease;
+    }
+    else if ("/etc/centos-release".equals(file.getAbsolutePath())){
+      return isOsCentOsRelease;
+    }
+    return false;
+  }
+
+  @Override
+  public ArrayList<String> readFile(File file) {
+    ArrayList<String> result = new ArrayList<>();
+    if("/etc/os-release".equals(file.getAbsolutePath())) {
+      result.add(ID.concat("=").concat(osReleaseId));
+      result.add(VERSION_ID.concat("=").concat(osReleaseVersionId));
+    }
+    else if ("/etc/redhat-release".equals(file.getAbsolutePath())){
+      result.add(osRedHatReleaseContent);
+    }
+    else if ("/etc/centos-release".equals(file.getAbsolutePath())){
+      result.add(osCentOsReleaseContent);
+    }
+    return result;
+  }
+
+  @Override
+  public String getEnv(String property) {
+    return osDistEnv;
+  }
+}


### PR DESCRIPTION
Added support for linux the following linux versions:
- Ubuntu-16.04
- Ubuntu-18.04
- RedHat/CentOS-6.2+
- RedHat/CentOS-7
- RedHat/CentOS-8

Also changed the file MongoDbVersion to allow user to any mongo version they want (earlier only version 4.2.4 was supported)